### PR TITLE
Make category formatting more clear in document

### DIFF
--- a/Coding-Handbook.md
+++ b/Coding-Handbook.md
@@ -6,19 +6,29 @@
 * RQ2: What are the Diversity & Inclusion issues that open science projects face?
   * RQ2.1: How are projects addressing these D&I issues?
   * RQ2.2: How does funding address these challenges?
-
+  
+  
+### Code Category Name
+**1. Project**
 | Code Name | Code Description |
 |---|---|
-| 1. Project| Measures - goals - challenges - prior successes |
 | a. Goals and Objectives | The objective or goal that the project has identified. May or may not be in response to a challenge the project has identified. For example, if the project identifies memory usage as a challenge for their software, software development to improve memory usage would be coded as a project goal. |
 | b. Challenges | Challenges that the project has identified. These may or may not be used to describe the need for funding. |
 | c. Prior Success | Projects identify their previous successful outcomes. Funding request may be to build on this success, or it may be an indicator that no funding is needed for this area. |
 |---|---|
-| 2. Project Type | Based on CZI project types - Biomedical or Foundational to all scientific research |
+
+### Code Category Name
+**2. Project Type**: Based on CZI project types - Biomedical or Foundational to all scientific research
+| Code Name | Code Description |
+|---|---|
 | a. Foundational | The project is foundational to all scientific research: 1) ML/Data analysis, 2) Visualization, and 3) Data management/workflows|
 | b. Domain Specific | The project is specific to Biomedical Research |
 |---|---|
-| 3. Project Activity| Project key activities|
+
+### Code Category Name
+**3. Project Activity**: Project key activities
+| Code Name | Code Description |
+|---|---|
 | a. New Piece of Software | The project is building a new piece of software (standalone). |
 | b. Software Improvement| The project is building a new feature within an existing piece of software. The project is improving functionality of an existing piece of software. This code may appear as a challenge, development activity, or as a goal to improve. Includes such things as optimization, scale, memory usage, and improving installation, and automation. Renamed from - New Software Feature and Merged to include improvements |
 | c. Software Maintenance | The ongoing maintenance of a project. This may include many ongoing activities, but common activities could include fixing bugs, and maintaining software interdependencies, and software testing. |
@@ -31,16 +41,25 @@
 | j. Project Measurement | Measuring project impact and productivity to improve the project. |
 | k. Research Activity | Conduct research based on project and publish papers and present research at conferences.|
 |---|---|
-| 4. Existing Resources | Resource the project has identified (often connected to prior success)|
+
+### Code Category Name
+**4. Existing Resources**: Resource the project has identified (often connected to prior success)
+| Code Name | Code Description |
+|---|---|
 | a. Existing Software | The project has or has built software for a scientific purpose. This can include descriptions and technical specifications for existing software or digital assets. |
 | b. Existing Facilities, Hardware, and Equipment | Labs, offices, servers, and equipment. Examples of this could include personal computers and servers. This can include descriptions and technical specifications for existing physical assets. |
 | c. Existing Paid Contributors| Work was done or is being done by paid contributors |
 | d. Existing Financial Support| The project has or has had prior financial support. Examples of this may travel, or any other miscellaneous expenses that are not explicitly stated as people or facilities and hardware expenses. |
 |---|---|
-|5. Project Funding Requests| Money that the project is explicitly asking for in the proposal|
+
+### Code Category Name
+**5. Project Funding Requests**: Money that the project is explicitly asking for in the proposal
+| Code Name | Code Description |
+|---|---|
 | a. Request for Facilities, Hardware, and Equipment | The project requests funding for hardware that enables the project to run. Examples of this could include personal computers and servers |
 | b. Funding for Salaried Position | The project is requesting money for paid contributors. |
 | c. Request for Travel Funding | The project is requesting funds for travel. |
 |---|---|
-|6. D&I | The Proposal mentions diversity and inclusion issues. This is being capture for future coding work. D&I has a seperate code book |
-|---|---|
+
+### Code Category Name
+**6. Diversity and Inclusion**: The Proposal mentions diversity and inclusion issues. This is being capture for future coding work. D&I has a seperate code book 

--- a/Coding-Handbook.md
+++ b/Coding-Handbook.md
@@ -8,8 +8,7 @@
   * RQ2.2: How does funding address these challenges?
   
   
-### Code Category Name
-**1. Project**
+### Code Category Name  **1. Project**: Measures - goals - challenges - prior successes
 | Code Name | Code Description |
 |---|---|
 | a. Goals and Objectives | The objective or goal that the project has identified. May or may not be in response to a challenge the project has identified. For example, if the project identifies memory usage as a challenge for their software, software development to improve memory usage would be coded as a project goal. |
@@ -17,16 +16,14 @@
 | c. Prior Success | Projects identify their previous successful outcomes. Funding request may be to build on this success, or it may be an indicator that no funding is needed for this area. |
 |---|---|
 
-### Code Category Name
-**2. Project Type**: Based on CZI project types - Biomedical or Foundational to all scientific research
+### Code Category Name  **2. Project Type**: Based on CZI project types - Biomedical or Foundational to all scientific research
 | Code Name | Code Description |
 |---|---|
 | a. Foundational | The project is foundational to all scientific research: 1) ML/Data analysis, 2) Visualization, and 3) Data management/workflows|
 | b. Domain Specific | The project is specific to Biomedical Research |
 |---|---|
 
-### Code Category Name
-**3. Project Activity**: Project key activities
+### Code Category Name  **3. Project Activity**: Project key activities
 | Code Name | Code Description |
 |---|---|
 | a. New Piece of Software | The project is building a new piece of software (standalone). |
@@ -42,8 +39,7 @@
 | k. Research Activity | Conduct research based on project and publish papers and present research at conferences.|
 |---|---|
 
-### Code Category Name
-**4. Existing Resources**: Resource the project has identified (often connected to prior success)
+### Code Category Name  **4. Existing Resources**: Resource the project has identified (often connected to prior success)
 | Code Name | Code Description |
 |---|---|
 | a. Existing Software | The project has or has built software for a scientific purpose. This can include descriptions and technical specifications for existing software or digital assets. |
@@ -52,8 +48,7 @@
 | d. Existing Financial Support| The project has or has had prior financial support. Examples of this may travel, or any other miscellaneous expenses that are not explicitly stated as people or facilities and hardware expenses. |
 |---|---|
 
-### Code Category Name
-**5. Project Funding Requests**: Money that the project is explicitly asking for in the proposal
+### Code Category Name  **5. Project Funding Requests**: Money that the project is explicitly asking for in the proposal
 | Code Name | Code Description |
 |---|---|
 | a. Request for Facilities, Hardware, and Equipment | The project requests funding for hardware that enables the project to run. Examples of this could include personal computers and servers |
@@ -61,5 +56,4 @@
 | c. Request for Travel Funding | The project is requesting funds for travel. |
 |---|---|
 
-### Code Category Name
-**6. Diversity and Inclusion**: The Proposal mentions diversity and inclusion issues. This is being capture for future coding work. D&I has a seperate code book 
+### Code Category Name  **6. Diversity and Inclusion**: The Proposal mentions diversity and inclusion issues. This is being capture for future coding work. D&I has a seperate code book 


### PR DESCRIPTION
Markdown does not easily permit indents in tables. I suggest the following format to make the differences between our code categories and codes more clear to the consumer of the codebook.